### PR TITLE
Added shortcuts for new quote wrapping function

### DIFF
--- a/keymaps/wrap-in-tag.cson
+++ b/keymaps/wrap-in-tag.cson
@@ -8,4 +8,5 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-workspace':
-  'alt-shift-w': 'wrap-in-tag:wrap'
+    'alt-w': 'wrap-in-tag:wrap'
+    'alt-shift-w': 'wrap-in-tag:wraptag'


### PR DESCRIPTION
Pressing ALT+W will now wrap your selection in quotation marks and allow you to type over them just as the great html tag wrap function always did. 