### PR TITLE
Added support to wrap quotation marks or other strings

### DIFF
--- a/lib/wrap-in-tag.coffee
+++ b/lib/wrap-in-tag.coffee
@@ -3,29 +3,44 @@ module.exports =
   activate: (state) ->
 
     atom.commands.add 'atom-workspace', 'wrap-in-tag:wrap': => @wrap()
+    atom.commands.add 'atom-workspace', 'wrap-in-tag:wraptag': => @wraptag()
 
   wrap: ->
     if editor = atom.workspace.getActiveTextEditor()
-      editor.getSelections().map((item) -> wrapSelection(editor, item))
+      editor.getSelections().map((item) -> wrapSelection(editor, item, 0))
+  wraptag: ->
+    if editor = atom.workspace.getActiveTextEditor()
+      editor.getSelections().map((item) -> wrapSelection(editor, item ,'p'))
 
-wrapSelection = (editor, selection) ->
-  tag = 'p'
+
+wrapSelection = (editor, selection, tag='p') ->
   text = selection.getText()
   tagRangePos = selection.getBufferRange()
 
-  newText = ['<', tag, '>', text, '</', tag, '>'].join('')
+  if tag # wrap a html tag:
+      newText = ['<', tag, '>', text, '</', tag, '>'].join('')
+      range =
+        start:
+          from: [tagRangePos.start.row, tagRangePos.start.column+1]
+          to: [tagRangePos.start.row, tagRangePos.start.column+2]
+        end:
+          from: [tagRangePos.end.row, tagRangePos.end.column+5],
+          to: [tagRangePos.end.row, tagRangePos.end.column+6]
 
-  range =
-    start:
-      from: [tagRangePos.start.row, tagRangePos.start.column+1]
-      to: [tagRangePos.start.row, tagRangePos.start.column+2]
-    end:
-      from: [tagRangePos.end.row, tagRangePos.end.column+5],
-      to: [tagRangePos.end.row, tagRangePos.end.column+6]
+      if range.end.from[0] > range.start.from[0]
+        range.end.from[1] = range.end.from[1] - 3
+        range.end.to[1] = range.end.to[1] - 3
 
-  if range.end.from[0] > range.start.from[0]
-    range.end.from[1] = range.end.from[1] - 3
-    range.end.to[1] = range.end.to[1] - 3
+  else #wrap a quote (or some other text):
+    newText = '"'+text+'"'
+    range =
+        start:
+            from: [tagRangePos.start.row, tagRangePos.start.column]
+            to: [tagRangePos.start.row, tagRangePos.start.column+1]
+        end:
+            from: [tagRangePos.end.row, tagRangePos.end.column+1],
+            to: [tagRangePos.end.row, tagRangePos.end.column+2]
+
 
   newStartTagSelectRange = [range.start.from, range.start.to]
   newEndTagSelectRange = [range.end.from, range.end.to]


### PR DESCRIPTION
Pressing ALT+W will now wrap your selection in quotation marks and allow you to type over them just as the great html tag wrap function always did.